### PR TITLE
CSS updates: Hidden Edit this page option, increased width for version

### DIFF
--- a/antora-bundle/src/css/nav.css
+++ b/antora-bundle/src/css/nav.css
@@ -182,7 +182,7 @@ html.is-clipped--nav {
 .nav-panel-explore .context .version {
   display: flex;
   align-items: inherit;
-  width: 5rem;
+  width: 6rem;
 }
 
 .nav-panel-explore .context .version::after {

--- a/antora-bundle/src/css/toolbar.css
+++ b/antora-bundle/src/css/toolbar.css
@@ -57,11 +57,12 @@
   padding-right: 0.5rem;
 }
 
+/* Commenting out for the embedded docs build
 @media screen and (min-width: 1024px) {
   .edit-this-page {
     display: block;
   }
-}
+} */
 
 .toolbar .edit-this-page a {
   color: var(--toolbar-muted-color);


### PR DESCRIPTION
- Hides `Edit this page` link on pages
   - ![image](https://user-images.githubusercontent.com/23069445/146282562-7411e12b-c2fb-4d6a-b82f-8da89569d8c9.png)

- fixes `latest` version bleeding into the next line
   - ![image](https://user-images.githubusercontent.com/23069445/146282501-4ab7dfcd-2bfd-443b-b989-58323388c9e3.png)
